### PR TITLE
[MIN-2432] Enum schema evolution SWIFT fork

### DIFF
--- a/Sources/SwiftProtobuf/JSONDecoder.swift
+++ b/Sources/SwiftProtobuf/JSONDecoder.swift
@@ -476,7 +476,7 @@ internal struct JSONDecoder: Decoder {
       value = nil
       return
     }
-    value = try scanner.nextEnumValue() as E
+    value = try scanner.nextEnumValue()
   }
 
   mutating func decodeSingularEnumField<E: Enum>(value: inout E) throws
@@ -489,7 +489,7 @@ internal struct JSONDecoder: Decoder {
       value = E()
       return
     }
-    value = try scanner.nextEnumValue()
+    value = try scanner.nextEnumValue() ?? E()
   }
 
   mutating func decodeRepeatedEnumField<E: Enum>(value: inout [E]) throws
@@ -511,8 +511,9 @@ internal struct JSONDecoder: Decoder {
           throw JSONDecodingError.illegalNull
         }
       } else {
-        let e: E = try scanner.nextEnumValue()
-        value.append(e)
+        if let e: E = try scanner.nextEnumValue() {
+          value.append(e)
+        }
       }
       if scanner.skipOptionalArrayEnd() {
         return

--- a/Sources/SwiftProtobuf/Version.swift
+++ b/Sources/SwiftProtobuf/Version.swift
@@ -25,4 +25,10 @@ public struct Version {
 
   /// String form of the version number.
   public static let versionString = "\(major).\(minor).\(revision)"
+
+  // We have unit tests that check that the runtime implementation is using the Noom's
+  // fork instead of the official implementation.
+  // We don't care about the specific version of the fork, only that the fork is indeed
+  // used.
+  public static let noomFork = true
 }

--- a/Tests/SwiftProtobufTests/TestHelpers.swift
+++ b/Tests/SwiftProtobufTests/TestHelpers.swift
@@ -218,12 +218,13 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
     func assertJSONDecodeSucceeds(
         _ json: String,
         extensions: ExtensionMap = SimpleExtensionMap(),
+        options: JSONDecodingOptions = JSONDecodingOptions(),
         file: XCTestFileArgType = #file,
         line: UInt = #line,
         check: (MessageTestType) -> Bool
     ) {
         do {
-            let decoded: MessageTestType = try MessageTestType(jsonString: json, extensions: extensions)
+            let decoded: MessageTestType = try MessageTestType(jsonString: json, extensions: extensions, options: options)
             XCTAssert(check(decoded), "Condition failed for \(decoded)", file: file, line: line)
 
             do {
@@ -245,7 +246,7 @@ extension PBTestHelpers where MessageTestType: SwiftProtobuf.Message & Equatable
 
         do {
             let jsonData = json.data(using: String.Encoding.utf8)!
-            let decoded: MessageTestType = try MessageTestType(jsonUTF8Data: jsonData, extensions: extensions)
+            let decoded: MessageTestType = try MessageTestType(jsonUTF8Data: jsonData, extensions: extensions, options: options)
             XCTAssert(check(decoded), "Condition failed for \(decoded) from binary \(json)", file: file, line: line)
 
             do {

--- a/Tests/SwiftProtobufTests/Test_Enum.swift
+++ b/Tests/SwiftProtobufTests/Test_Enum.swift
@@ -16,6 +16,7 @@
 
 import Foundation
 import XCTest
+import SwiftProtobuf
 
 class Test_Enum: XCTestCase, PBTestHelpers {
     typealias MessageTestType = Proto3Unittest_TestAllTypes
@@ -37,6 +38,23 @@ class Test_Enum: XCTestCase, PBTestHelpers {
     func testJSONrepeated() {
         assertJSONEncode("{\"repeatedNestedEnum\":[\"FOO\",\"BAR\"]}") { (m: inout MessageTestType) in
             m.repeatedNestedEnum = [.foo, .bar]
+        }
+    }
+
+    func testJSONdecodingOptions() {
+
+        var options = JSONDecodingOptions()
+        options.ignoreUnknownFields = true
+
+        assertJSONDecodeSucceeds("{\"optionalNestedEnum\":\"NEW_VALUE\"}", options: options) { (m: MessageTestType) -> Bool in
+            switch m.optionalNestedEnum {
+            case .zero: return true
+            default: return false
+            }
+        }
+
+        assertJSONDecodeSucceeds("{\"repeatedNestedEnum\":[\"FOO\",\"NEW_VALUE\"]}", options: options) { (m: MessageTestType) -> Bool in
+            m.repeatedNestedEnum == [.foo]
         }
     }
 

--- a/Tests/SwiftProtobufTests/Test_Enum.swift
+++ b/Tests/SwiftProtobufTests/Test_Enum.swift
@@ -41,7 +41,7 @@ class Test_Enum: XCTestCase, PBTestHelpers {
         }
     }
 
-    func testJSONdecodingOptions() {
+    func testIgnoreUnknownEnumCase() {
 
         var options = JSONDecodingOptions()
         options.ignoreUnknownFields = true


### PR DESCRIPTION
# DON'T MERGE THIS PR

This is PR is just a visual representation of our JSON enum fork. Learn more in the [original Tech Doc](https://docs.google.com/document/d/1p5LUSTWrVBcT9F2wXBgHBDT3OJyOm5BpXAyTpwwDVts/edit#heading=h.artn9vazslxe).

# Motivation

This PR helps us visualize code changes that we've made to protobuf library wrt JSON schema evolution.

Tech Doc:
https://docs.google.com/document/d/1p5LUSTWrVBcT9F2wXBgHBDT3OJyOm5BpXAyTpwwDVts/edit#

# Setup

The baseline branch `json_unknown_enum_fork_baseline` is pinned to a version of the upstream repository on the version specified by:
https://github.com/noom/noom-contracts/blob/master/lib/swift/SWIFT_PROTOBUF_VERSION

This can be checked by running a command similar to `git diff json_unknown_enum_fork_baseline 1.18.0`, which should always produce empty results.

The head branch for this PR `json_unknown_enum_fork`, shows all changes that we've made to the upstream repository.

# Changes

If you want to make changes to our fork, create a PR that merges to `json_unknown_enum_fork`.

# Installation

To release the new fork version, do:

```
git checkout json_unknown_enum_fork
git tag ${SWIFT_PROTOBUF_VERSION_WITHOUT_PATCH}.1000
git push origin --tags
```

Bump the noomfork patch version  (`1000`) every time to the next increment.

The SWIFT_PROTOBUF_VERSION is the version on which the baseline branch `json_unknown_enum_fork_baseline` is.

Then in noom-contracts, do the change similar to https://github.com/noom/noom-contracts/pull/292.

# Testing in `swift-protobuf` repo

Run from the repository root:

```
swift test
```

# When does the fork end?

Once protobuf team decides what to do with JSON enum schema evolution, we will end the fork and implement whatever they decide upstream. They will announce it here:
https://github.com/protocolbuffers/protobuf/issues/7392
